### PR TITLE
Add xUnit test project

### DIFF
--- a/root/Source/Freedi.Tests/Freedi.Tests.csproj
+++ b/root/Source/Freedi.Tests/Freedi.Tests.csproj
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{77B69B91-83F6-4D65-AAF7-000000000001}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Freedi.Tests</RootNamespace>
+    <AssemblyName>Freedi.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="HomeControllerTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Freedi.Website\Freedi.Website.csproj">
+      <Project>{5493F5EE-38C5-45DC-8397-095DBA8FED5B}</Project>
+      <Name>Freedi.Website</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Freedi.Logic\Freedi.Logic.csproj">
+      <Project>{D3877976-8326-4665-BA5D-5035DFFDD543}</Project>
+      <Name>Freedi.Logic</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Freedi.Common\Freedi.Common.csproj">
+      <Project>{BB060EC9-DA6F-4FD6-A42A-9DD9A922EAF2}</Project>
+      <Name>Freedi.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Freedi.DataProvider\Freedi.DataProvider.csproj">
+      <Project>{40C2E583-29F0-44BD-BF23-AE5D9295E797}</Project>
+      <Name>Freedi.DataProvider</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Freedi.Model\Freedi.Model.csproj">
+      <Project>{4F3A4B70-C94B-472F-9863-4DE9C94EE344}</Project>
+      <Name>Freedi.Model</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/root/Source/Freedi.Tests/HomeControllerTests.cs
+++ b/root/Source/Freedi.Tests/HomeControllerTests.cs
@@ -1,0 +1,41 @@
+using Xunit;
+using Freedi.Website.Controllers;
+using System.Web.Mvc;
+
+namespace Freedi.Tests
+{
+    public class HomeControllerTests
+    {
+        [Fact]
+        public void Index_returns_view()
+        {
+            var controller = new HomeController();
+
+            var result = controller.Index() as ViewResult;
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void About_sets_message()
+        {
+            var controller = new HomeController();
+
+            var result = controller.About() as ViewResult;
+
+            Assert.NotNull(result);
+            Assert.Equal("Your application description page.", result.ViewBag.Message);
+        }
+
+        [Fact]
+        public void Contact_sets_message()
+        {
+            var controller = new HomeController();
+
+            var result = controller.Contact() as ViewResult;
+
+            Assert.NotNull(result);
+            Assert.Equal("Your contact page.", result.ViewBag.Message);
+        }
+    }
+}

--- a/root/Source/Freedi.Tests/Properties/AssemblyInfo.cs
+++ b/root/Source/Freedi.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,15 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Freedi.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Freedi.Tests")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: ComVisible(false)]
+[assembly: Guid("23a5d82e-005d-4e77-9dc4-000000000001")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/root/Source/Freedi.Tests/packages.config
+++ b/root/Source/Freedi.Tests/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.runner.visualstudio" version="2.4.3" targetFramework="net471" />
+</packages>

--- a/root/Source/Freedi.Website.sln
+++ b/root/Source/Freedi.Website.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Freedi.DataProvider", "Free
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Freedi.Model", "Freedi.Model\Freedi.Model.csproj", "{4F3A4B70-C94B-472F-9863-4DE9C94EE344}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Freedi.Tests", "Freedi.Tests\Freedi.Tests.csproj", "{77B69B91-83F6-4D65-AAF7-000000000001}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,8 +40,12 @@ Global
 		{4F3A4B70-C94B-472F-9863-4DE9C94EE344}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4F3A4B70-C94B-472F-9863-4DE9C94EE344}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F3A4B70-C94B-472F-9863-4DE9C94EE344}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4F3A4B70-C94B-472F-9863-4DE9C94EE344}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {4F3A4B70-C94B-472F-9863-4DE9C94EE344}.Release|Any CPU.Build.0 = Release|Any CPU
+                {77B69B91-83F6-4D65-AAF7-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {77B69B91-83F6-4D65-AAF7-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {77B69B91-83F6-4D65-AAF7-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {77B69B91-83F6-4D65-AAF7-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add `Freedi.Tests` project to solution
- hook up dependencies on existing libraries
- configure xUnit via `packages.config`
- implement basic `HomeController` tests

## Testing
- `dotnet test root/Source/Freedi.Website.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685121cbbb888325a8cda99195fd719c