### PR TITLE
Add basic Web API project

### DIFF
--- a/root/Source/Freedi.Api/App_Start/WebApiConfig.cs
+++ b/root/Source/Freedi.Api/App_Start/WebApiConfig.cs
@@ -1,0 +1,18 @@
+using System.Web.Http;
+
+namespace Freedi.Api
+{
+    public static class WebApiConfig
+    {
+        public static void Register(HttpConfiguration config)
+        {
+            config.MapHttpAttributeRoutes();
+
+            config.Routes.MapHttpRoute(
+                name: "DefaultApi",
+                routeTemplate: "api/{controller}/{id}",
+                defaults: new { id = RouteParameter.Optional }
+            );
+        }
+    }
+}

--- a/root/Source/Freedi.Api/Controllers/ValuesController.cs
+++ b/root/Source/Freedi.Api/Controllers/ValuesController.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Web.Http;
+using Freedi.Logic;
+
+namespace Freedi.Api.Controllers
+{
+    public class ValuesController : ApiController
+    {
+        // GET api/values
+        public IEnumerable<string> Get()
+        {
+            var logic = new Class1();
+            var pong = logic.Ping();
+            return new [] { "value1", pong };
+        }
+
+        // GET api/values/5
+        public string Get(int id)
+        {
+            return "value";
+        }
+
+        // POST api/values
+        public void Post([FromBody]string value)
+        {
+        }
+
+        // PUT api/values/5
+        public void Put(int id, [FromBody]string value)
+        {
+        }
+
+        // DELETE api/values/5
+        public void Delete(int id)
+        {
+        }
+    }
+}

--- a/root/Source/Freedi.Api/Freedi.Api.csproj
+++ b/root/Source/Freedi.Api/Freedi.Api.csproj
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{819CB869-D1FF-414D-B36D-51D099732C62}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Freedi.Api</RootNamespace>
+    <AssemblyName>Freedi.Api</AssemblyName>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Web.Http, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.4\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.4\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App_Start\WebApiConfig.cs" />
+    <Compile Include="Controllers\ValuesController.cs" />
+    <Compile Include="Global.asax.cs">
+      <DependentUpon>Global.asax</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Global.asax" />
+    <Content Include="Web.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Freedi.Logic\Freedi.Logic.csproj">
+      <Project>{D3877976-8326-4665-BA5D-5035DFFDD543}</Project>
+      <Name>Freedi.Logic</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/root/Source/Freedi.Api/Global.asax
+++ b/root/Source/Freedi.Api/Global.asax
@@ -1,0 +1,1 @@
+<%@ Application Language="C#" Inherits="Freedi.Api.WebApiApplication" %>

--- a/root/Source/Freedi.Api/Global.asax.cs
+++ b/root/Source/Freedi.Api/Global.asax.cs
@@ -1,0 +1,12 @@
+using System.Web.Http;
+
+namespace Freedi.Api
+{
+    public class WebApiApplication : System.Web.HttpApplication
+    {
+        protected void Application_Start()
+        {
+            GlobalConfiguration.Configure(WebApiConfig.Register);
+        }
+    }
+}

--- a/root/Source/Freedi.Api/Properties/AssemblyInfo.cs
+++ b/root/Source/Freedi.Api/Properties/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Freedi.Api")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Freedi")]
+[assembly: AssemblyProduct("Freedi.Api")]
+[assembly: AssemblyCopyright("Copyright © Freedi")]
+[assembly: AssemblyTrademark("")]
+[assembly: ComVisible(false)]
+[assembly: Guid("b5000000-0000-0000-0000-000000000001")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/root/Source/Freedi.Api/Web.config
+++ b/root/Source/Freedi.Api/Web.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.web>
+    <compilation debug="true" targetFramework="4.7.1" />
+    <httpRuntime targetFramework="4.7.1" />
+  </system.web>
+  <system.webServer>
+    <modules runAllManagedModulesForAllRequests="true" />
+  </system.webServer>
+</configuration>

--- a/root/Source/Freedi.Api/packages.config
+++ b/root/Source/Freedi.Api/packages.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi" version="5.2.4" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.4" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.4" targetFramework="net471" />
+</packages>

--- a/root/Source/Freedi.Logic/Class1.cs
+++ b/root/Source/Freedi.Logic/Class1.cs
@@ -8,5 +8,9 @@ namespace Freedi.Logic
 {
     public class Class1
     {
+        public string Ping()
+        {
+            return "Pong";
+        }
     }
 }

--- a/root/Source/Freedi.Website.sln
+++ b/root/Source/Freedi.Website.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Freedi.DataProvider", "Free
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Freedi.Model", "Freedi.Model\Freedi.Model.csproj", "{4F3A4B70-C94B-472F-9863-4DE9C94EE344}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Freedi.Api", "Freedi.Api\Freedi.Api.csproj", "{819CB869-D1FF-414D-B36D-51D099732C62}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,8 +40,12 @@ Global
 		{4F3A4B70-C94B-472F-9863-4DE9C94EE344}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4F3A4B70-C94B-472F-9863-4DE9C94EE344}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F3A4B70-C94B-472F-9863-4DE9C94EE344}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4F3A4B70-C94B-472F-9863-4DE9C94EE344}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {4F3A4B70-C94B-472F-9863-4DE9C94EE344}.Release|Any CPU.Build.0 = Release|Any CPU
+                {819CB869-D1FF-414D-B36D-51D099732C62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {819CB869-D1FF-414D-B36D-51D099732C62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {819CB869-D1FF-414D-B36D-51D099732C62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {819CB869-D1FF-414D-B36D-51D099732C62}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- create **Freedi.Api** project for ASP.NET Web API
- register default API route and implement basic `ValuesController`
- reference `Freedi.Logic` and expose simple `Ping` method
- update solution file and add packages for Web API

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685121d0b244832587998c3b89f538a0